### PR TITLE
Tendermint chains support - v0.34.8 based

### DIFF
--- a/projects/gateway_cosmos/releases.json
+++ b/projects/gateway_cosmos/releases.json
@@ -9,7 +9,7 @@
                         "description": "cosmoshub-4 support",
                         "bundles": {
                             "linux-amd64.supervisor": {
-                                "runner": "linux-amd64.supervisor.runner01",
+                                "runner": "linux-amd64.supervisor.runner02",
                                 "data": {
                                     "gateway": "http://public.artifacts.marlin.pro/projects/gateway_cosmos/2.0.0/cosmos_gateway-linux_amd64",
                                     "gateway_checksum": "66ed97039a8875919fc80c0c69c0f8b8",

--- a/projects/gateway_cosmos/releases.json
+++ b/projects/gateway_cosmos/releases.json
@@ -6,15 +6,15 @@
                 "0": {
                     "0": {
                         "time": "05 Apr 21 15:06 +0530",
-                        "description": "Iris mainnet 1.0 support",
+                        "description": "cosmoshub-4 support",
                         "bundles": {
                             "linux-amd64.supervisor": {
                                 "runner": "linux-amd64.supervisor.runner01",
                                 "data": {
-                                    "gateway": "http://public.artifacts.marlin.pro/projects/gateway_iris/2.0.0/iris_gateway-linux_amd64",
-                                    "gateway_checksum": "618082435b86946a5217a4f630923d4f",
-                                    "bridge": "http://public.artifacts.marlin.pro/projects/gateway_iris/2.0.0/iris_bridge-linux_amd64",
-                                    "bridge_checksum": "f6668fdd3e48b5db4998e82aeca19a23"
+                                    "gateway": "http://public.artifacts.marlin.pro/projects/gateway_cosmos/2.0.0/cosmos_gateway-linux_amd64",
+                                    "gateway_checksum": "66ed97039a8875919fc80c0c69c0f8b8",
+                                    "bridge": "http://public.artifacts.marlin.pro/projects/gateway_cosmos/2.0.0/cosmos_bridge-linux_amd64",
+                                    "bridge_checksum": "34e9f55fca0d226b3c6b11c7dc49dafb"
                                 }
                             }
                         }

--- a/projects/gateway_iris/releases.json
+++ b/projects/gateway_iris/releases.json
@@ -9,7 +9,7 @@
                         "description": "Iris mainnet 1.0 support",
                         "bundles": {
                             "linux-amd64.supervisor": {
-                                "runner": "linux-amd64.supervisor.runner01",
+                                "runner": "linux-amd64.supervisor.runner02",
                                 "data": {
                                     "gateway": "http://public.artifacts.marlin.pro/projects/gateway_iris/2.0.0/iris_gateway-linux_amd64",
                                     "gateway_checksum": "618082435b86946a5217a4f630923d4f",

--- a/projects/marlinctl/releases.json
+++ b/projects/marlinctl/releases.json
@@ -65,6 +65,23 @@
                         }
                     }
                 }
+            },
+            "2": {
+                "0": {
+                    "0": {
+                        "time": "05 Apr 21 15:50 +0530",
+                        "description": "Tendermint chains based on v0.34.8 TMcore supported",
+                        "bundles": {
+                            "linux-amd64": {
+                                "runner": "",
+                                "data": {
+                                    "executable": "http://public.artifacts.marlin.pro/projects/marlinctl/2.2.0/marlinctl-2.2.0-linux-amd64",
+                                    "checksum": "95dd8660b4d6c282fffb38889d37567e"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Tendermint chains support.

Support extended for:
- iris mainnet 1.0 (artifacts v2.0.0)
- cosmoshub-4 mainnet (artifacts v2.0.0)

MarlinCTL release v2.2.0

Tested and presanity done on branch `tmv34` for "public".